### PR TITLE
다크 모드 기반 공통 및 페이지별 CSS 추가

### DIFF
--- a/static/css/help/dollimpan.css
+++ b/static/css/help/dollimpan.css
@@ -1,0 +1,11 @@
+h1 {
+    margin-bottom: 0.9rem;
+}
+
+p {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 1rem;
+    padding: 1.2rem;
+    box-shadow: var(--shadow);
+}

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -1,0 +1,14 @@
+body {
+    display: grid;
+    place-items: center;
+    gap: 1.1rem;
+}
+
+h1 {
+    text-align: center;
+}
+
+body > div {
+    display: flex;
+    justify-content: center;
+}

--- a/static/css/license/index.css
+++ b/static/css/license/index.css
@@ -1,0 +1,10 @@
+body {
+    display: grid;
+    gap: 1rem;
+}
+
+body > div {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.7rem;
+}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,0 +1,126 @@
+:root {
+    --bg-primary: #0b0f1a;
+    --bg-secondary: #121a2b;
+    --surface: rgba(255, 255, 255, 0.04);
+    --surface-hover: rgba(255, 255, 255, 0.09);
+    --text-primary: #f3f7ff;
+    --text-secondary: #afbdd8;
+    --accent: #6ea8ff;
+    --accent-strong: #4f8cff;
+    --border: rgba(255, 255, 255, 0.14);
+    --shadow: 0 20px 50px rgba(0, 0, 0, 0.45);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html,
+body {
+    margin: 0;
+    min-height: 100%;
+}
+
+body {
+    font-family: "Pretendard", "Noto Sans KR", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    background:
+        radial-gradient(circle at 10% 20%, rgba(110, 168, 255, 0.25), transparent 35%),
+        radial-gradient(circle at 80% 10%, rgba(122, 235, 205, 0.15), transparent 40%),
+        linear-gradient(160deg, var(--bg-primary), var(--bg-secondary));
+    color: var(--text-primary);
+    line-height: 1.6;
+    padding: 3rem 1.5rem;
+}
+
+main,
+body > div,
+body > p,
+body > h1 {
+    width: min(900px, 100%);
+    margin-left: auto;
+    margin-right: auto;
+}
+
+h1 {
+    margin-top: 0;
+    font-size: clamp(1.8rem, 4vw, 2.5rem);
+    letter-spacing: -0.02em;
+    text-wrap: balance;
+}
+
+p {
+    color: var(--text-secondary);
+}
+
+a {
+    color: var(--accent);
+}
+
+a:hover {
+    color: #b9d6ff;
+}
+
+button {
+    border: 1px solid var(--border);
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.03));
+    color: var(--text-primary);
+    padding: 0.7rem 1.15rem;
+    border-radius: 0.8rem;
+    cursor: pointer;
+    transition: transform 0.18s ease, background-color 0.2s ease, box-shadow 0.2s ease;
+    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.25);
+}
+
+button:hover {
+    transform: translateY(-2px) scale(1.01);
+    background: linear-gradient(180deg, rgba(110, 168, 255, 0.22), rgba(79, 140, 255, 0.12));
+    box-shadow: 0 12px 20px rgba(5, 8, 16, 0.42);
+}
+
+button:active {
+    transform: translateY(0);
+}
+
+button:focus-visible,
+a:focus-visible {
+    outline: 2px solid var(--accent-strong);
+    outline-offset: 2px;
+}
+
+.card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 1rem;
+    padding: 1.2rem;
+    box-shadow: var(--shadow);
+    backdrop-filter: blur(10px);
+}
+
+.interactive-glow {
+    position: relative;
+    overflow: hidden;
+}
+
+.interactive-glow::after {
+    content: "";
+    position: absolute;
+    inset: -1px;
+    background: radial-gradient(circle at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(110, 168, 255, 0.2), transparent 45%);
+    opacity: 0;
+    transition: opacity 0.25s ease;
+    pointer-events: none;
+}
+
+.interactive-glow:hover::after {
+    opacity: 1;
+}
+
+@media (max-width: 640px) {
+    body {
+        padding: 2rem 1rem;
+    }
+
+    button {
+        width: 100%;
+    }
+}

--- a/templates/help/dollimpan.html
+++ b/templates/help/dollimpan.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Link CSS file -->
     <link rel="stylesheet" href="/static/css/style.css?v={{ static_version('static/css/style.css') }}">
+    <link rel="stylesheet" href="/static/css/help/dollimpan.css?v={{ static_version('static/css/help/dollimpan.css') }}">
     <title>돌림판 - 도움말</title>
 </head>
 <body>
@@ -19,5 +20,13 @@
         - 입력값은 한국어와 영어만 지원하며, 최대 4자까지 입력할 수 있습니다.<br>
     </p>
     <script src="/static/js/footer.js?v={{ static_version('static/js/footer.js') }}"></script>
+    <script>
+        document.body.addEventListener("pointermove", (event) => {
+            const x = `${(event.clientX / window.innerWidth) * 100}%`;
+            const y = `${(event.clientY / window.innerHeight) * 100}%`;
+            document.documentElement.style.setProperty("--mouse-x", x);
+            document.documentElement.style.setProperty("--mouse-y", y);
+        });
+    </script>
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Link CSS file -->
-    <link rel="stylesheet" href="/static/style.css?v={{ static_version('static/css/style.css') }}">
+    <link rel="stylesheet" href="/static/css/style.css?v={{ static_version('static/css/style.css') }}">
+    <link rel="stylesheet" href="/static/css/index.css?v={{ static_version('static/css/index.css') }}">
     <!-- Set favicon -->
     <link rel="icon" type="image/png" href="/static/favicon/favicon-96x96.png?v=20260512" sizes="96x96">
     <link rel="icon" type="image/svg+xml" href="/static/favicon/favicon.svg?v=20260512">
@@ -20,8 +21,16 @@
         HaeengIn의 웹 사이트에 오신 것을 환영합니다!
     </h1>
     <div>
-        <button onclick="location.href='/license'">허가 증명</button>
+        <button class="interactive-glow" onclick="location.href='/license'">허가 증명</button>
     </div>
     <script defer src="/static/js/footer.js?v={{ static_version('static/js/footer.js') }}"></script>
+    <script>
+        document.body.addEventListener("pointermove", (event) => {
+            const x = `${(event.clientX / window.innerWidth) * 100}%`;
+            const y = `${(event.clientY / window.innerHeight) * 100}%`;
+            document.documentElement.style.setProperty("--mouse-x", x);
+            document.documentElement.style.setProperty("--mouse-y", y);
+        });
+    </script>
 </body>
 </html>

--- a/templates/license/index.html
+++ b/templates/license/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Link CSS file -->
+    <link rel="stylesheet" href="/static/css/style.css?v={{ static_version('static/css/style.css') }}">
+    <link rel="stylesheet" href="/static/css/license/index.css?v={{ static_version('static/css/license/index.css') }}">
     <!-- Set favicon -->
     <link rel="icon" type="image/png" href="/static/favicon/favicon-96x96.png?v=20260512" sizes="96x96">
     <link rel="icon" type="image/svg+xml" href="/static/favicon/favicon.svg?v=20260512">
@@ -17,11 +19,19 @@
 <body>
     <h1>허가 증명 스크린샷</h1>
     <div>
-        <button onclick="location.href='/license/wppengine'">월 페이퍼 엔진</button>
-        <button onclick="location.href='/license/7bg'">작곡가 허가 증명</button>
+        <button class="interactive-glow" onclick="location.href='/license/wppengine'">월 페이퍼 엔진</button>
+        <button class="interactive-glow" onclick="location.href='/license/7bg'">작곡가 허가 증명</button>
     </div>
     <div>
-        <button onclick="location.href='/'">홈으로</button>
+        <button class="interactive-glow" onclick="location.href='/'">홈으로</button>
     </div>
+    <script>
+        document.body.addEventListener("pointermove", (event) => {
+            const x = `${(event.clientX / window.innerWidth) * 100}%`;
+            const y = `${(event.clientY / window.innerHeight) * 100}%`;
+            document.documentElement.style.setProperty("--mouse-x", x);
+            document.documentElement.style.setProperty("--mouse-y", y);
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- 사이트 전역에 다크 모드 기반의 현대적이고 세련된 UI를 적용하고 페이지별 스타일을 분리하여 유지보수성을 높이며 마우스 포인터와 상호작용하는 시각 효과를 제공하기 위해 변경했습니다.

### Description
- 전역 테마와 컴포넌트 스타일을 `static/css/style.css`에 추가하고 색상 토큰, 그라디언트 배경, 타이포그래피, 버튼 상태 및 `interactive-glow` 포인터 효과를 구현했습니다.
- 페이지 전용 스타일을 `static/css/index.css`, `static/css/help/dollimpan.css`, `static/css/license/index.css`로 분리하여 각 템플릿 레이아웃을 정리했습니다.
- `templates/index.html`, `templates/help/dollimpan.html`, `templates/license/index.html`을 수정해 전역 CSS와 페이지별 CSS를 로드하도록 링크를 정리하고 버튼에 `interactive-glow` 클래스를 적용했습니다.
- 포인터 이동 시 CSS 변수 `--mouse-x`/`--mouse-y`를 갱신하는 스크립트를 각 템플릿에 추가하고 잘못된 경로(`/static/style.css`)를 `/static/css/style.css`로 수정했습니다.

### Testing
- `git status --short`를 실행해 변경 사항을 확인했고 성공했습니다.
- 변경 파일들을 `git add` 후 `git commit -m "Implement modern dark-mode global and per-page CSS"`로 커밋했으며 커밋이 성공했습니다.
- PR 생성 작업(`make_pr`)을 실행해 PR 제목/본문을 생성했고 정상적으로 응답을 받았습니다.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04078a05b8832cad3ab42fbdc01f6b)