### PR TITLE
Add modern dark-mode design system and per-page template CSS

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,0 +1,152 @@
+:root {
+    --bg-primary: #0b1020;
+    --bg-secondary: #121a31;
+    --bg-elevated: #18223f;
+    --text-primary: #e7ebff;
+    --text-muted: #a7b0d9;
+    --accent: #6ea8ff;
+    --accent-2: #9b7bff;
+    --border: rgba(160, 180, 255, 0.2);
+    --shadow: 0 16px 40px rgba(0, 0, 0, 0.45);
+    --radius: 14px;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html,
+body {
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    min-height: 100vh;
+    font-family: "Pretendard", "Noto Sans KR", "Segoe UI", sans-serif;
+    line-height: 1.6;
+    color: var(--text-primary);
+    background:
+        radial-gradient(circle at 10% 10%, rgba(110, 168, 255, 0.18), transparent 40%),
+        radial-gradient(circle at 90% 0%, rgba(155, 123, 255, 0.18), transparent 30%),
+        linear-gradient(160deg, #060912, var(--bg-primary) 30%, #090d1b 100%);
+    padding: 2.5rem 1.25rem 3.5rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.25rem;
+}
+
+h1,
+h2,
+h3,
+h4,
+p {
+    margin: 0;
+}
+
+h1,
+h2,
+h3,
+h4 {
+    letter-spacing: -0.01em;
+}
+
+h1 {
+    font-size: clamp(1.8rem, 3vw, 2.5rem);
+    text-align: center;
+}
+
+h2 {
+    font-size: clamp(1.4rem, 2.2vw, 1.8rem);
+}
+
+h3 {
+    font-size: clamp(1.05rem, 1.8vw, 1.3rem);
+    color: var(--text-muted);
+}
+
+h4,
+p {
+    color: var(--text-muted);
+}
+
+a {
+    color: var(--accent);
+}
+
+body > div {
+    width: min(960px, 100%);
+}
+
+button {
+    position: relative;
+    border: 1px solid var(--border);
+    background: linear-gradient(145deg, rgba(110, 168, 255, 0.18), rgba(155, 123, 255, 0.15));
+    color: var(--text-primary);
+    padding: 0.72rem 1.05rem;
+    border-radius: 10px;
+    font-weight: 600;
+    cursor: pointer;
+    backdrop-filter: blur(4px);
+    transition: transform 0.18s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+    box-shadow: 0 10px 24px rgba(11, 16, 32, 0.45);
+}
+
+button:hover {
+    transform: translateY(-1px) scale(1.01);
+    box-shadow: 0 0 0 1px rgba(110, 168, 255, 0.55), 0 12px 26px rgba(9, 20, 60, 0.45);
+    border-color: rgba(110, 168, 255, 0.65);
+}
+
+button:active {
+    transform: translateY(0) scale(0.995);
+}
+
+button:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}
+
+.card {
+    background: linear-gradient(180deg, rgba(24, 34, 63, 0.72), rgba(11, 16, 32, 0.8));
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    width: min(960px, 100%);
+    padding: 1.15rem 1.2rem;
+}
+
+.with-cursor-glow {
+    position: relative;
+    overflow: hidden;
+    isolation: isolate;
+}
+
+.with-cursor-glow::before {
+    content: "";
+    position: absolute;
+    inset: -120px;
+    background: radial-gradient(circle at var(--mx, 50%) var(--my, 50%), rgba(110, 168, 255, 0.24), transparent 24%);
+    transition: opacity 0.22s ease;
+    opacity: 0;
+    pointer-events: none;
+    z-index: -1;
+}
+
+.with-cursor-glow:hover::before {
+    opacity: 1;
+}
+
+img {
+    max-width: 100%;
+    height: auto;
+    border-radius: 10px;
+    border: 1px solid var(--border);
+}
+
+@media (max-width: 640px) {
+    body {
+        padding: 1.4rem 0.9rem 2.5rem;
+    }
+}

--- a/static/css/templates/help/dollimpan.css
+++ b/static/css/templates/help/dollimpan.css
@@ -1,0 +1,8 @@
+p {
+    width: min(720px, 100%);
+    padding: 1rem 1.1rem;
+    background: rgba(24, 34, 63, 0.7);
+    border: 1px solid rgba(160, 180, 255, 0.2);
+    border-radius: 12px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.32);
+}

--- a/static/css/templates/index.css
+++ b/static/css/templates/index.css
@@ -1,0 +1,4 @@
+body > div {
+    display: flex;
+    justify-content: center;
+}

--- a/static/css/templates/license/index.css
+++ b/static/css/templates/license/index.css
@@ -1,0 +1,6 @@
+body > div {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 0.65rem;
+}

--- a/static/css/templates/license/wppengine/index.css
+++ b/static/css/templates/license/wppengine/index.css
@@ -1,0 +1,9 @@
+h3 {
+    text-align: center;
+    margin-top: 0.2rem;
+}
+
+body > div {
+    display: flex;
+    justify-content: center;
+}

--- a/static/css/templates/license/wppengine/shiro.css
+++ b/static/css/templates/license/wppengine/shiro.css
@@ -1,0 +1,21 @@
+body {
+    gap: 0.9rem;
+}
+
+body > div {
+    width: min(960px, 100%);
+    padding: 1rem 1rem 1.1rem;
+    background: rgba(24, 34, 63, 0.72);
+    border: 1px solid rgba(160, 180, 255, 0.2);
+    border-radius: 14px;
+    box-shadow: 0 12px 26px rgba(0, 0, 0, 0.35);
+}
+
+h3,
+h4 {
+    margin-top: 0.25rem;
+}
+
+img {
+    margin-top: 0.75rem;
+}

--- a/static/js/footer.js
+++ b/static/js/footer.js
@@ -58,4 +58,13 @@ OS/플랫폼: ${platform}
     footer.appendChild(report);
     footer.appendChild(contact)
     document.body.appendChild(footer);
+
+    // 마우스 위치 기반 글로우 효과
+    document.addEventListener("pointermove", function (event) {
+        const x = `${Math.round((event.clientX / window.innerWidth) * 100)}%`;
+        const y = `${Math.round((event.clientY / window.innerHeight) * 100)}%`;
+        document.body.style.setProperty("--mx", x);
+        document.body.style.setProperty("--my", y);
+    });
+
 });

--- a/templates/help/dollimpan.html
+++ b/templates/help/dollimpan.html
@@ -6,9 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Link CSS file -->
     <link rel="stylesheet" href="/static/css/style.css?v={{ static_version('static/css/style.css') }}">
+    <link rel="stylesheet" href="/static/css/templates/help/dollimpan.css?v={{ static_version('static/css/templates/help/dollimpan.css') }}">
     <title>돌림판 - 도움말</title>
 </head>
-<body>
+<body class="with-cursor-glow">
     <h1>
         돌림판 - 도움말
     </h1>

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Link CSS file -->
-    <link rel="stylesheet" href="/static/style.css?v={{ static_version('static/css/style.css') }}">
+    <link rel="stylesheet" href="/static/css/style.css?v={{ static_version('static/css/style.css') }}">
+    <link rel="stylesheet" href="/static/css/templates/index.css?v={{ static_version('static/css/templates/index.css') }}">
     <!-- Set favicon -->
     <link rel="icon" type="image/png" href="/static/favicon/favicon-96x96.png?v=20260512" sizes="96x96">
     <link rel="icon" type="image/svg+xml" href="/static/favicon/favicon.svg?v=20260512">
@@ -15,7 +16,7 @@
     <!-- Title of page -->
     <title>HaeengIn's Website</title>
 </head>
-<body>
+<body class="with-cursor-glow">
     <h1>
         HaeengIn의 웹 사이트에 오신 것을 환영합니다!
     </h1>

--- a/templates/license/index.html
+++ b/templates/license/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Link CSS file -->
+    <link rel="stylesheet" href="/static/css/style.css?v={{ static_version('static/css/style.css') }}">
+    <link rel="stylesheet" href="/static/css/templates/license/index.css?v={{ static_version('static/css/templates/license/index.css') }}">
     <!-- Set favicon -->
     <link rel="icon" type="image/png" href="/static/favicon/favicon-96x96.png?v=20260512" sizes="96x96">
     <link rel="icon" type="image/svg+xml" href="/static/favicon/favicon.svg?v=20260512">
@@ -14,7 +16,7 @@
     <!-- Title of page -->
     <title>허가 증명 스크린샷</title>
 </head>
-<body>
+<body class="with-cursor-glow">
     <h1>허가 증명 스크린샷</h1>
     <div>
         <button onclick="location.href='/license/wppengine'">월 페이퍼 엔진</button>
@@ -23,5 +25,6 @@
     <div>
         <button onclick="location.href='/'">홈으로</button>
     </div>
+    <script defer src="/static/js/footer.js?v={{ static_version('static/js/footer.js') }}"></script>
 </body>
 </html>

--- a/templates/license/wppengine/index.html
+++ b/templates/license/wppengine/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Link CSS file -->
+    <link rel="stylesheet" href="/static/css/style.css?v={{ static_version('static/css/style.css') }}">
+    <link rel="stylesheet" href="/static/css/templates/license/wppengine/index.css?v={{ static_version('static/css/templates/license/wppengine/index.css') }}">
     <!-- Set favicon -->
     <link rel="icon" type="image/png" href="/static/favicon/favicon-96x96.png?v=20260512" sizes="96x96">
     <link rel="icon" type="image/svg+xml" href="/static/favicon/favicon.svg?v=20260512">
@@ -14,12 +16,13 @@
     <!-- Title of page -->
     <title>허가 증명 스크린샷 - 월 페이퍼 엔진</title>
 </head>
-<body>
+<body class="with-cursor-glow">
     <h1>월 페이퍼 엔진</h1>
     <h2>Wallpaper Engine</h2>
     <h3>항목을 눌러 월 페이퍼의 허가 증명 스크린샷을 확인하세요.</h3>
     <div>
         <button onclick="location.href='/license/wppengine/shiro'">DJ Raisei - SHIRO</button>
     </div>
+    <script defer src="/static/js/footer.js?v={{ static_version('static/js/footer.js') }}"></script>
 </body>
 </html>

--- a/templates/license/wppengine/shiro.html
+++ b/templates/license/wppengine/shiro.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Link CSS file -->
+    <link rel="stylesheet" href="/static/css/style.css?v={{ static_version('static/css/style.css') }}">
+    <link rel="stylesheet" href="/static/css/templates/license/wppengine/shiro.css?v={{ static_version('static/css/templates/license/wppengine/shiro.css') }}">
     <!-- Set favicon -->
     <link rel="icon" type="image/png" href="/static/favicon/favicon-96x96.png?v=20260512" sizes="96x96">
     <link rel="icon" type="image/svg+xml" href="/static/favicon/favicon.svg?v=20260512">
@@ -14,7 +16,7 @@
     <!-- Title of page -->
     <title>Wallpaper Engine - SHIRO</title>
 </head>
-<body>
+<body class="with-cursor-glow">
     {% for item in verifications %}
     <div>
         <h2>{{ item.name }}</h2>
@@ -25,5 +27,6 @@
         {% endif %}
     </div>
     {% endfor %}
+    <script defer src="/static/js/footer.js?v={{ static_version('static/js/footer.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Provide a cohesive dark-mode visual system across the site with modern typography, spacing, and reusable components.  
- Scope page-specific overrides into per-template CSS files to keep styles organized by template hierarchy.  
- Add a subtle cursor-tracking glow interaction to improve perceived polish and interactivity.  
- Ensure the footer script and interaction are consistently included across license and help pages so behavior is uniform.

### Description
- Added a global design system in `static/css/style.css` containing CSS variables, gradients, typography, button/card styles, responsive layout rules, and a `.with-cursor-glow` helper for cursor-based glow effects.  
- Introduced page-scoped CSS files under `static/css/templates/` mirroring template paths: `index.css`, `help/dollimpan.css`, `license/index.css`, `license/wppengine/index.css`, and `license/wppengine/shiro.css`.  
- Updated templates to consistently load the global stylesheet and the corresponding per-page stylesheet and applied `class="with-cursor-glow"` on `body` to enable the glow layer.  
- Extended `static/js/footer.js` to update CSS variables `--mx` and `--my` on `pointermove` so the glow follows the pointer, and ensured the footer script is included on pages that previously omitted it.

### Testing
- Verified presence of new and modified files using `rg --files` which listed the created CSS files.  
- Inspected the generated CSS and JS content with `sed -n` to confirm the design tokens and the `pointermove` handler were added to `static/css/style.css` and `static/js/footer.js`.  
- Reviewed updated templates with `sed -n`/`nl -ba` to confirm the added stylesheet links and `body` class are present.  
- All automated file inspections completed successfully (files created and expected content found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04078a05b8832cad3ab42fbdc01f6b)