### PR TITLE
Modern dark-mode redesign with global and per-page CSS and pointer interaction

### DIFF
--- a/static/css/help/dollimpan.css
+++ b/static/css/help/dollimpan.css
@@ -1,0 +1,13 @@
+body {
+    place-content: start center;
+}
+
+p {
+    padding: 1.1rem 1.25rem;
+    background: var(--surface);
+    border: 1px solid var(--surface-border);
+    border-radius: var(--radius);
+    max-width: 760px;
+    color: #d8e5ff;
+    box-shadow: var(--shadow);
+}

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -1,0 +1,9 @@
+body {
+    justify-items: center;
+    text-align: center;
+}
+
+body > div {
+    display: flex;
+    gap: 0.75rem;
+}

--- a/static/css/license/index.css
+++ b/static/css/license/index.css
@@ -1,0 +1,11 @@
+body {
+    justify-items: center;
+    text-align: center;
+}
+
+body > div {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    justify-content: center;
+}

--- a/static/css/license/wppengine/index.css
+++ b/static/css/license/wppengine/index.css
@@ -1,0 +1,8 @@
+body {
+    justify-items: center;
+    text-align: center;
+}
+
+div {
+    margin-top: 0.65rem;
+}

--- a/static/css/license/wppengine/shiro.css
+++ b/static/css/license/wppengine/shiro.css
@@ -1,0 +1,14 @@
+body {
+    place-content: start center;
+}
+
+body > div {
+    width: min(100%, 1040px);
+    padding: 1rem;
+    border-radius: var(--radius);
+    background: var(--surface);
+    border: 1px solid var(--surface-border);
+    box-shadow: var(--shadow);
+    display: grid;
+    gap: 0.6rem;
+}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,0 +1,108 @@
+:root {
+    color-scheme: dark;
+    --bg-primary: #070b14;
+    --bg-secondary: #101828;
+    --surface: rgba(20, 30, 48, 0.72);
+    --surface-border: rgba(137, 180, 255, 0.18);
+    --text-primary: #f5f8ff;
+    --text-secondary: #a9bad6;
+    --accent: #6ea8ff;
+    --accent-strong: #8a6eff;
+    --success: #6dd0a6;
+    --shadow: 0 20px 45px rgba(0, 0, 0, 0.38);
+    --radius: 18px;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html,
+body {
+    margin: 0;
+    min-height: 100%;
+}
+
+body {
+    position: relative;
+    display: grid;
+    gap: 1.25rem;
+    place-content: center;
+    padding: clamp(1.25rem, 4vw, 3rem);
+    font-family: "Inter", "Pretendard", "Noto Sans KR", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    line-height: 1.55;
+    letter-spacing: 0.01em;
+    color: var(--text-primary);
+    background:
+        radial-gradient(circle at 15% 20%, rgba(110, 168, 255, 0.22), transparent 30%),
+        radial-gradient(circle at 80% 10%, rgba(138, 110, 255, 0.2), transparent 32%),
+        linear-gradient(160deg, var(--bg-primary), #080d1e 42%, var(--bg-secondary));
+    overflow-x: hidden;
+}
+
+body::before {
+    content: "";
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    background: radial-gradient(180px circle at var(--mx, 50%) var(--my, 50%), rgba(110, 168, 255, 0.2), transparent 72%);
+    transition: background-position 0.12s linear;
+    z-index: 0;
+}
+
+body > * {
+    position: relative;
+    z-index: 1;
+}
+
+h1,
+h2,
+h3,
+h4,
+p {
+    margin: 0;
+}
+
+h1 { font-size: clamp(1.7rem, 3vw, 2.4rem); }
+h2 { font-size: clamp(1.35rem, 2.2vw, 1.8rem); color: #e3eeff; }
+h3, h4 { color: var(--text-secondary); }
+
+a,
+button {
+    cursor: pointer;
+}
+
+button {
+    border: 1px solid rgba(173, 205, 255, 0.28);
+    border-radius: 12px;
+    background: linear-gradient(140deg, rgba(110, 168, 255, 0.26), rgba(138, 110, 255, 0.17));
+    color: var(--text-primary);
+    font-weight: 600;
+    font-size: 0.95rem;
+    padding: 0.7rem 1rem;
+    backdrop-filter: blur(8px);
+    box-shadow: 0 8px 24px rgba(7, 13, 28, 0.5);
+    transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+
+button:hover {
+    transform: translateY(-2px) scale(1.01);
+    border-color: rgba(173, 205, 255, 0.45);
+    box-shadow: 0 14px 30px rgba(70, 110, 195, 0.35);
+}
+
+button:active {
+    transform: translateY(0);
+}
+
+img {
+    width: min(100%, 980px);
+    height: auto;
+    border-radius: 14px;
+    border: 1px solid rgba(173, 205, 255, 0.22);
+    box-shadow: var(--shadow);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after { transition: none !important; animation: none !important; }
+}

--- a/static/js/footer.js
+++ b/static/js/footer.js
@@ -58,4 +58,11 @@ OS/플랫폼: ${platform}
     footer.appendChild(report);
     footer.appendChild(contact)
     document.body.appendChild(footer);
+
+    // 마우스 포인터 인터랙션 배경 좌표 반영
+    window.addEventListener("pointermove", (event) => {
+        document.body.style.setProperty("--mx", `${event.clientX}px`);
+        document.body.style.setProperty("--my", `${event.clientY}px`);
+    });
+
 });

--- a/templates/help/dollimpan.html
+++ b/templates/help/dollimpan.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Link CSS file -->
     <link rel="stylesheet" href="/static/css/style.css?v={{ static_version('static/css/style.css') }}">
+    <link rel="stylesheet" href="/static/css/help/dollimpan.css?v={{ static_version('static/css/help/dollimpan.css') }}">
     <title>돌림판 - 도움말</title>
 </head>
 <body>

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Link CSS file -->
-    <link rel="stylesheet" href="/static/style.css?v={{ static_version('static/css/style.css') }}">
+    <link rel="stylesheet" href="/static/css/style.css?v={{ static_version('static/css/style.css') }}">
+    <link rel="stylesheet" href="/static/css/index.css?v={{ static_version('static/css/index.css') }}">
     <!-- Set favicon -->
     <link rel="icon" type="image/png" href="/static/favicon/favicon-96x96.png?v=20260512" sizes="96x96">
     <link rel="icon" type="image/svg+xml" href="/static/favicon/favicon.svg?v=20260512">

--- a/templates/license/index.html
+++ b/templates/license/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Link CSS file -->
+    <link rel="stylesheet" href="/static/css/style.css?v={{ static_version('static/css/style.css') }}">
+    <link rel="stylesheet" href="/static/css/license/index.css?v={{ static_version('static/css/license/index.css') }}">
     <!-- Set favicon -->
     <link rel="icon" type="image/png" href="/static/favicon/favicon-96x96.png?v=20260512" sizes="96x96">
     <link rel="icon" type="image/svg+xml" href="/static/favicon/favicon.svg?v=20260512">
@@ -23,5 +25,6 @@
     <div>
         <button onclick="location.href='/'">홈으로</button>
     </div>
+    <script defer src="/static/js/footer.js?v={{ static_version('static/js/footer.js') }}"></script>
 </body>
 </html>

--- a/templates/license/wppengine/index.html
+++ b/templates/license/wppengine/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Link CSS file -->
+    <link rel="stylesheet" href="/static/css/style.css?v={{ static_version('static/css/style.css') }}">
+    <link rel="stylesheet" href="/static/css/license/wppengine/index.css?v={{ static_version('static/css/license/wppengine/index.css') }}">
     <!-- Set favicon -->
     <link rel="icon" type="image/png" href="/static/favicon/favicon-96x96.png?v=20260512" sizes="96x96">
     <link rel="icon" type="image/svg+xml" href="/static/favicon/favicon.svg?v=20260512">
@@ -21,5 +23,6 @@
     <div>
         <button onclick="location.href='/license/wppengine/shiro'">DJ Raisei - SHIRO</button>
     </div>
+    <script defer src="/static/js/footer.js?v={{ static_version('static/js/footer.js') }}"></script>
 </body>
 </html>

--- a/templates/license/wppengine/shiro.html
+++ b/templates/license/wppengine/shiro.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Link CSS file -->
+    <link rel="stylesheet" href="/static/css/style.css?v={{ static_version('static/css/style.css') }}">
+    <link rel="stylesheet" href="/static/css/license/wppengine/shiro.css?v={{ static_version('static/css/license/wppengine/shiro.css') }}">
     <!-- Set favicon -->
     <link rel="icon" type="image/png" href="/static/favicon/favicon-96x96.png?v=20260512" sizes="96x96">
     <link rel="icon" type="image/svg+xml" href="/static/favicon/favicon.svg?v=20260512">
@@ -25,5 +27,6 @@
         {% endif %}
     </div>
     {% endfor %}
+    <script defer src="/static/js/footer.js?v={{ static_version('static/js/footer.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation

- Provide a unified dark-mode, modern visual design across the site with improved typography, glass-like surfaces, and refined controls.
- Add subtle pointer-driven background interaction to make the UI feel more dynamic and responsive to user input.
- Allow per-page layout adjustments by adding page-scoped CSS files so templates can remain minimal while getting tailored styling.

### Description

- Added a new global stylesheet `static/css/style.css` with CSS variables, gradients, glass-surface styles, accessible motion preferences, and a `body::before` spotlight that reads `--mx`/`--my` for pointer-driven highlights.
- Created page-specific stylesheets: `static/css/index.css`, `static/css/help/dollimpan.css`, `static/css/license/index.css`, `static/css/license/wppengine/index.css`, and `static/css/license/wppengine/shiro.css` to hold template-specific layout tweaks.
- Updated templates to load both the global stylesheet and the corresponding page stylesheet, and corrected the home stylesheet path to `/static/css/style.css`.
- Added a `pointermove` handler to `static/js/footer.js` that updates `--mx`/`--my` so the CSS spotlight follows the cursor and ensured the footer script is included where missing.

### Testing

- Enumerated repository files with `rg --files` and confirmed the new CSS files are present and correctly placed; this inspection succeeded.
- Inspected template and asset contents using `sed -n` and `nl -ba` to verify that templates reference `static/css/style.css`, include their page CSS, and include the footer script; all checks matched expectations.
- Reviewed the generated diff and file listings to ensure no missing references and that the pointer handler is present in `static/js/footer.js`; these verifications succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04078a05b8832cad3ab42fbdc01f6b)