### PR TITLE
style: convert global theme colors from blue to grayscale

### DIFF
--- a/static/css/license/wppengine/shiro.css
+++ b/static/css/license/wppengine/shiro.css
@@ -1,5 +1,6 @@
 body {
     place-content: start center;
+    justify-items: center;
 }
 
 body > div {
@@ -11,4 +12,6 @@ body > div {
     box-shadow: var(--shadow);
     display: grid;
     gap: 0.6rem;
+    justify-items: center;
+    text-align: center;
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,6 +1,6 @@
 :root {
     color-scheme: dark;
-    --bg-primary: #0b0b0b;
+    --bg-primary: #2e2e2e;
     --bg-secondary: #1a1a1a;
     --surface: rgba(36, 36, 36, 0.72);
     --surface-border: rgba(255, 255, 255, 0.14);
@@ -38,11 +38,11 @@ body {
 }
 
 body::before {
-    content: none;
+    content: "";
     position: fixed;
     inset: 0;
     pointer-events: none;
-    background: none;
+    background: radial-gradient(160px circle at var(--mx, 50%) var(--my, 50%), rgba(255, 255, 255, 0.12), transparent 72%);
     transition: background-position 0.12s linear;
     z-index: 0;
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,6 +1,6 @@
 :root {
     color-scheme: dark;
-    --bg-primary: #2e2e2e;
+    --bg-primary: #1c1c1f;
     --bg-secondary: #1a1a1a;
     --surface: rgba(36, 36, 36, 0.72);
     --surface-border: rgba(255, 255, 255, 0.14);

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -33,19 +33,16 @@ body {
     line-height: 1.55;
     letter-spacing: 0.01em;
     color: var(--text-primary);
-    background:
-        radial-gradient(circle at 15% 20%, rgba(255, 255, 255, 0.08), transparent 30%),
-        radial-gradient(circle at 80% 10%, rgba(200, 200, 200, 0.08), transparent 32%),
-        linear-gradient(160deg, var(--bg-primary), #121212 42%, var(--bg-secondary));
+    background: var(--bg-primary);
     overflow-x: hidden;
 }
 
 body::before {
-    content: "";
+    content: none;
     position: fixed;
     inset: 0;
     pointer-events: none;
-    background: radial-gradient(180px circle at var(--mx, 50%) var(--my, 50%), rgba(255, 255, 255, 0.12), transparent 72%);
+    background: none;
     transition: background-position 0.12s linear;
     z-index: 0;
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -42,7 +42,14 @@ body::before {
     position: fixed;
     inset: 0;
     pointer-events: none;
-    background: radial-gradient(160px circle at var(--mx, 50%) var(--my, 50%), rgba(255, 255, 255, 0.12), transparent 72%);
+    background: radial-gradient(
+        240px circle at var(--mx, 50%) var(--my, 50%),
+        rgba(255, 255, 255, 0.14) 0%,
+        rgba(255, 255, 255, 0.08) 38%,
+        rgba(255, 255, 255, 0.03) 64%,
+        rgba(255, 255, 255, 0) 100%
+    );
+    filter: blur(10px);
     transition: background-position 0.12s linear;
     z-index: 0;
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,14 +1,14 @@
 :root {
     color-scheme: dark;
-    --bg-primary: #070b14;
-    --bg-secondary: #101828;
-    --surface: rgba(20, 30, 48, 0.72);
-    --surface-border: rgba(137, 180, 255, 0.18);
-    --text-primary: #f5f8ff;
-    --text-secondary: #a9bad6;
-    --accent: #6ea8ff;
-    --accent-strong: #8a6eff;
-    --success: #6dd0a6;
+    --bg-primary: #0b0b0b;
+    --bg-secondary: #1a1a1a;
+    --surface: rgba(36, 36, 36, 0.72);
+    --surface-border: rgba(255, 255, 255, 0.14);
+    --text-primary: #f2f2f2;
+    --text-secondary: #b3b3b3;
+    --accent: #d9d9d9;
+    --accent-strong: #ffffff;
+    --success: #c9c9c9;
     --shadow: 0 20px 45px rgba(0, 0, 0, 0.38);
     --radius: 18px;
 }
@@ -34,9 +34,9 @@ body {
     letter-spacing: 0.01em;
     color: var(--text-primary);
     background:
-        radial-gradient(circle at 15% 20%, rgba(110, 168, 255, 0.22), transparent 30%),
-        radial-gradient(circle at 80% 10%, rgba(138, 110, 255, 0.2), transparent 32%),
-        linear-gradient(160deg, var(--bg-primary), #080d1e 42%, var(--bg-secondary));
+        radial-gradient(circle at 15% 20%, rgba(255, 255, 255, 0.08), transparent 30%),
+        radial-gradient(circle at 80% 10%, rgba(200, 200, 200, 0.08), transparent 32%),
+        linear-gradient(160deg, var(--bg-primary), #121212 42%, var(--bg-secondary));
     overflow-x: hidden;
 }
 
@@ -45,7 +45,7 @@ body::before {
     position: fixed;
     inset: 0;
     pointer-events: none;
-    background: radial-gradient(180px circle at var(--mx, 50%) var(--my, 50%), rgba(110, 168, 255, 0.2), transparent 72%);
+    background: radial-gradient(180px circle at var(--mx, 50%) var(--my, 50%), rgba(255, 255, 255, 0.12), transparent 72%);
     transition: background-position 0.12s linear;
     z-index: 0;
 }
@@ -64,7 +64,7 @@ p {
 }
 
 h1 { font-size: clamp(1.7rem, 3vw, 2.4rem); }
-h2 { font-size: clamp(1.35rem, 2.2vw, 1.8rem); color: #e3eeff; }
+h2 { font-size: clamp(1.35rem, 2.2vw, 1.8rem); color: #e5e5e5; }
 h3, h4 { color: var(--text-secondary); }
 
 a,
@@ -73,9 +73,9 @@ button {
 }
 
 button {
-    border: 1px solid rgba(173, 205, 255, 0.28);
+    border: 1px solid rgba(255, 255, 255, 0.24);
     border-radius: 12px;
-    background: linear-gradient(140deg, rgba(110, 168, 255, 0.26), rgba(138, 110, 255, 0.17));
+    background: linear-gradient(140deg, rgba(255, 255, 255, 0.14), rgba(180, 180, 180, 0.12));
     color: var(--text-primary);
     font-weight: 600;
     font-size: 0.95rem;
@@ -87,8 +87,8 @@ button {
 
 button:hover {
     transform: translateY(-2px) scale(1.01);
-    border-color: rgba(173, 205, 255, 0.45);
-    box-shadow: 0 14px 30px rgba(70, 110, 195, 0.35);
+    border-color: rgba(255, 255, 255, 0.4);
+    box-shadow: 0 14px 30px rgba(0, 0, 0, 0.38);
 }
 
 button:active {
@@ -99,7 +99,7 @@ img {
     width: min(100%, 980px);
     height: auto;
     border-radius: 14px;
-    border: 1px solid rgba(173, 205, 255, 0.22);
+    border: 1px solid rgba(255, 255, 255, 0.2);
     box-shadow: var(--shadow);
 }
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -42,16 +42,14 @@ body::before {
     position: fixed;
     inset: 0;
     pointer-events: none;
-    background: radial-gradient(
-        240px circle at var(--mx, 50%) var(--my, 50%),
-        rgba(255, 255, 255, 0.14) 0%,
-        rgba(255, 255, 255, 0.08) 38%,
-        rgba(255, 255, 255, 0.03) 64%,
-        rgba(255, 255, 255, 0) 100%
-    );
-    filter: blur(10px);
-    transition: background-position 0.12s linear;
+    background: radial-gradient(160px circle at var(--mx, 50%) var(--my, 50%), rgba(255, 255, 255, 0.12), transparent 72%);
+    opacity: 0;
+    transition: opacity 1s ease, background-position 0.12s linear;
     z-index: 0;
+}
+
+body.mouse-glow-visible::before {
+    opacity: 1;
 }
 
 body > * {

--- a/static/js/footer.js
+++ b/static/js/footer.js
@@ -60,9 +60,15 @@ OS/플랫폼: ${platform}
     document.body.appendChild(footer);
 
     // 마우스 포인터 인터랙션 배경 좌표 반영
+    let glowHideTimer;
     window.addEventListener("pointermove", (event) => {
         document.body.style.setProperty("--mx", `${event.clientX}px`);
         document.body.style.setProperty("--my", `${event.clientY}px`);
+        document.body.classList.add("mouse-glow-visible");
+        clearTimeout(glowHideTimer);
+        glowHideTimer = setTimeout(() => {
+            document.body.classList.remove("mouse-glow-visible");
+        }, 200);
     });
 
 });

--- a/static/js/footer.js
+++ b/static/js/footer.js
@@ -68,7 +68,7 @@ OS/플랫폼: ${platform}
         clearTimeout(glowHideTimer);
         glowHideTimer = setTimeout(() => {
             document.body.classList.remove("mouse-glow-visible");
-        }, 200);
+        }, 3000);
     });
 
 });


### PR DESCRIPTION
### Motivation
- Remove the dominant blue/purple visual and make the global theme neutral using black/gray/white tones for a more monochrome appearance.
- Ensure UI primitives (background, overlays, buttons, images, headings) follow the updated neutral palette for visual consistency.

### Description
- Replaced color tokens in `:root` inside `static/css/style.css`, switching `--bg-*`, `--surface`, `--text-*`, `--accent*`, and `--success` from blue/purple values to black/gray/white values.
- Updated page background gradients and the interactive highlight overlay (`body` and `body::before`) to use subtle gray/white radial and linear gradients.
- Adjusted text and component styling including `h2` color, `button` border/background and hover shadow, and `img` border to match the grayscale palette.

### Testing
- No automated tests were run because this is a visual/style-only change affecting `static/css/style.css`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04170bb518832c9b0ef70d3239467d)