### PR TITLE
Remove font-related styles from static CSS

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -29,9 +29,7 @@ body {
     gap: 1.25rem;
     place-content: center;
     padding: clamp(1.25rem, 4vw, 3rem);
-    font-family: "Inter", "Pretendard", "Noto Sans KR", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
     line-height: 1.55;
-    letter-spacing: 0.01em;
     color: var(--text-primary);
     background: var(--bg-primary);
     overflow-x: hidden;
@@ -65,8 +63,7 @@ p {
     margin: 0;
 }
 
-h1 { font-size: clamp(1.7rem, 3vw, 2.4rem); }
-h2 { font-size: clamp(1.35rem, 2.2vw, 1.8rem); color: #e5e5e5; }
+h2 { color: #e5e5e5; }
 h3, h4 { color: var(--text-secondary); }
 
 a,
@@ -79,8 +76,6 @@ button {
     border-radius: 12px;
     background: linear-gradient(140deg, rgba(255, 255, 255, 0.14), rgba(180, 180, 180, 0.12));
     color: var(--text-primary);
-    font-weight: 600;
-    font-size: 0.95rem;
     padding: 0.7rem 1rem;
     backdrop-filter: blur(8px);
     box-shadow: 0 8px 24px rgba(7, 13, 28, 0.5);


### PR DESCRIPTION
### Motivation
- Allow typography to be redefined from scratch by removing global font settings in the stylesheet.
- Prevent global font-size/weight rules from overriding per-component font choices.

### Description
- Removed the body-level `font-family` and `letter-spacing` declarations from `static/css/style.css`.
- Removed global heading `h1`/`h2` font-size rules and button `font-weight`/`font-size` rules to avoid implicit typography assumptions.
- Kept non-typography styles (colors, layout, spacing, shadows, etc.) unchanged.

### Testing
- Ran `rg -n "font|@font-face|letter-spacing" static/css` and confirmed there are no remaining matches, validating removal of font-related declarations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0548621d98832c930376df75331e5e)